### PR TITLE
Add vertical book component using Swiper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hangman",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "swiper": "^11.1.1"
+  }
+}

--- a/src/components/VerticalBook.tsx
+++ b/src/components/VerticalBook.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Pagination, Navigation, EffectCreative } from 'swiper/modules';
+
+import 'swiper/css';
+import 'swiper/css/pagination';
+import 'swiper/css/navigation';
+import 'swiper/css/effect-creative';
+
+const dummyText = `日本語のダミー文章がここに入ります。本文は縦書きで表示され、右から左へページをめくることができます。`;
+
+const pages = [dummyText, dummyText, dummyText];
+
+const VerticalBook: FC = () => {
+  return (
+    <Swiper
+      modules={[Pagination, Navigation, EffectCreative]}
+      pagination={{ clickable: true }}
+      navigation
+      effect="creative"
+      creativeEffect={{
+        prev: {
+          shadow: true,
+          translate: [0, 0, -400],
+        },
+        next: {
+          translate: ['100%', 0, 0],
+        },
+      }}
+      className="w-full h-screen"
+      dir="rtl"
+    >
+      {pages.map((text, index) => (
+        <SwiperSlide key={index}>
+          <div
+            className="p-8 text-xl leading-relaxed"
+            style={{ writingMode: 'vertical-rl', textOrientation: 'mixed' }}
+          >
+            {text}
+          </div>
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+};
+
+export default VerticalBook;


### PR DESCRIPTION
## Summary
- add swiper as dependency
- create VerticalBook component with pagination, navigation, and creative page-turn effect

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/swiper)
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6890c623a1648328ad4dd42024891e37