### PR TITLE
Add dynamic book page with vertical pagination

### DIFF
--- a/src/app/books/[id]/page.tsx
+++ b/src/app/books/[id]/page.tsx
@@ -1,0 +1,36 @@
+import VerticalBook from '@/components/VerticalBook';
+
+interface PageProps {
+  params: { id: string };
+}
+
+function splitIntoPages(text: string, charsPerPage: number): string[] {
+  const pages = [] as string[];
+  for (let i = 0; i < text.length; i += charsPerPage) {
+    pages.push(text.slice(i, i + charsPerPage));
+  }
+  return pages;
+}
+
+export default async function BookPage({ params }: PageProps) {
+  const { id } = params;
+
+  // Dummy data for demonstration
+  const title = `Dummy Book ${id}`;
+  const content = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.`.repeat(5);
+
+  const pages = splitIntoPages(content, 500);
+
+  const cover = (
+    <div className="h-full w-full flex flex-col items-center justify-center bg-gray-800 text-white p-4">
+      <h1 className="text-3xl font-bold mb-4">{title}</h1>
+      <p>Tap to begin</p>
+    </div>
+  );
+
+  const pageElements = pages.map((p, idx) => (
+    <div key={idx} className="p-4 whitespace-pre-wrap">{p}</div>
+  ));
+
+  return <VerticalBook pages={[cover, ...pageElements]} />;
+}

--- a/src/components/VerticalBook.tsx
+++ b/src/components/VerticalBook.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface VerticalBookProps {
+  pages: React.ReactNode[];
+}
+
+/**
+ * A simple vertical book component that renders a series of pages.
+ * Each page is rendered in a vertical stack that can be styled for
+ * page turning animations.
+ */
+export default function VerticalBook({ pages }: VerticalBookProps) {
+  return (
+    <div className="vertical-book">
+      {pages.map((page, index) => (
+        <div key={index} className="page">
+          {page}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `VerticalBook` component for rendering pages in a vertical book layout
- implement `/books/[id]` page that splits content into pages, injects a cover, and passes pages to `VerticalBook`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c624b3988328a1d50733d4950243