### PR TITLE
Add vertical reader utilities and typed components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# hangman
+# Hangman
+
+This project showcases a simple vertical text reader built with React and [Swiper](https://swiperjs.com/).
+
+## Vertical layout
+
+Pages are displayed in a Japanese-style vertical layout by applying CSS `writing-mode: vertical-rl` to the text container. This rotates the flow of characters so they are read from top to bottom and right to left.
+
+## Swiper settings
+
+`PageSwiper` uses Swiper's React component with `direction="vertical"` so users can swipe up or down between pages. Each page is a `SwiperSlide`.
+
+## Directory structure
+
+```
+src/
+  components/
+    App.tsx          # Root component.
+    PageSwiper.tsx   # Renders paginated vertical text using Swiper.
+  lib/
+    splitPages.ts    # Splits a string into fixed-length pages.
+    dummyData.ts     # Generates placeholder text for the demo.
+```
+
+## Usage
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm start
+```

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import PageSwiper from './PageSwiper';
+
+/**
+ * App is the root component for the Hangman reader demo.
+ * It simply renders the PageSwiper component.
+ */
+export const App: React.FC = () => <PageSwiper />;
+
+export default App;

--- a/src/components/PageSwiper.tsx
+++ b/src/components/PageSwiper.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { splitPages } from '../lib/splitPages';
+import { createDummyData } from '../lib/dummyData';
+
+/**
+ * PageSwiper renders vertical pages inside a Swiper component.
+ * It accepts optional text and page size, splitting content into Swiper slides.
+ */
+export interface PageSwiperProps {
+  /** Source text to be displayed. */
+  text?: string;
+  /** Maximum characters per page. */
+  pageSize?: number;
+}
+
+export const PageSwiper: React.FC<PageSwiperProps> = ({
+  text = createDummyData(400),
+  pageSize = 100,
+}) => {
+  const pages = React.useMemo(() => splitPages(text, pageSize), [text, pageSize]);
+
+  return (
+    <Swiper direction="vertical">
+      {pages.map((page, index) => (
+        <SwiperSlide key={index}>
+          <div style={{ writingMode: 'vertical-rl' }}>{page}</div>
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+};
+
+export default PageSwiper;

--- a/src/lib/dummyData.ts
+++ b/src/lib/dummyData.ts
@@ -1,0 +1,14 @@
+/**
+ * createDummyData generates placeholder Japanese text for demonstrations.
+ *
+ * @param length - Number of characters to generate.
+ * @returns A string consisting of repeated hiragana characters.
+ */
+export function createDummyData(length: number): string {
+  const seed = 'あいうえおかきくけこさしすせそたちつてとなにぬねの';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += seed[i % seed.length];
+  }
+  return result;
+}

--- a/src/lib/splitPages.ts
+++ b/src/lib/splitPages.ts
@@ -1,0 +1,15 @@
+/**
+ * splitPages breaks the provided text into pages.
+ * Each page contains up to the specified number of characters.
+ *
+ * @param text - The source string to split.
+ * @param pageSize - Maximum characters per page.
+ * @returns Array of paginated strings.
+ */
+export function splitPages(text: string, pageSize: number): string[] {
+  const pages: string[] = [];
+  for (let i = 0; i < text.length; i += pageSize) {
+    pages.push(text.slice(i, i + pageSize));
+  }
+  return pages;
+}


### PR DESCRIPTION
## Summary
- add page splitting and dummy data utilities
- create typed PageSwiper and App components using vertical layout
- document vertical writing, Swiper configuration, and directory structure in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c62591a88328b15a036d0fcc80b6